### PR TITLE
Alt language selector

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -14,6 +14,8 @@ pyramid.default_locale_name = eng_GB
 pyramid.includes =
     pyramid_debugtoolbar
 
+thumbor.security_key = aef7Ohghie8toi
+
 available_languages = [('eng_GB', 'English'), ('spa_ES', 'Spanish'), ('urd_PK', 'Urdu')]
 
 git.path = %(here)s/repo/

--- a/unicorecmsmnm/static/css/style.css
+++ b/unicorecmsmnm/static/css/style.css
@@ -13,8 +13,36 @@
 
 /*  LANG  */
 
-    .lang { padding: 5px 16px; text-align: right; background: #EBEBEB;}
-    [dir='rtl'] .lang {text-align: left; }
+    .lang {
+        padding: 5px 16px;
+        text-align: right;
+        background: #EBEBEB;
+        color: #bbb;
+    }
+    
+    [dir='rtl'] .lang {
+        text-align: left;
+    }
+
+    .lang-more-rtl {
+        display: none;
+    }
+
+    [dir='rtl'] .lang-more-rtl {
+        display: inline;
+    }
+
+    [dir='rtl'] .lang-more-lrt {
+        display: none;
+    }
+
+    .lang .active {
+        color: #999;
+    }
+
+
+
+
 /*  HEADER  */
 
     #header { padding: 10px; background: #fff; text-align: center; border-bottom: 2px solid #e9e9e9; }

--- a/unicorecmsmnm/static/css/style.css
+++ b/unicorecmsmnm/static/css/style.css
@@ -24,24 +24,15 @@
         text-align: left;
     }
 
-    .lang-more-rtl {
-        display: none;
-    }
-
-    [dir='rtl'] .lang-more-rtl {
-        display: inline;
-    }
-
-    [dir='rtl'] .lang-more-lrt {
-        display: none;
-    }
-
     .lang .active {
         color: #999;
     }
 
-
-
+    .lang-change {
+        position: relative;
+        top: -3px;
+        font-weight: bold;
+    }
 
 /*  HEADER  */
 

--- a/unicorecmsmnm/templates/base.pt
+++ b/unicorecmsmnm/templates/base.pt
@@ -19,10 +19,10 @@
 <body>
 <div id="wrap">
     <div class="lang">
-      <span tal:repeat="item view.get_available_languages">
-        <a href="/locale/?language=${item[0]}">${item[1]}</a>
-        <span tal:omit-tag="" tal:condition="not repeat.item.end"> |</span>
+      <span tal:repeat="item view.get_display_languages()">
+        <a tal:attributes="{'class':'active'} if view.locale==item[0] else {}" href="/locale/${item[0]}/">${item[1]}</a> |
       </span>
+      <a href="/locale/change/">&rarr;</a>
     </div>
 
     <div id="header">

--- a/unicorecmsmnm/templates/base.pt
+++ b/unicorecmsmnm/templates/base.pt
@@ -14,7 +14,7 @@
     <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;" />
     <meta name="description" content=""/>
     <meta name="keywords" content="malaria, health"/>
-    <link href="${request.static_url('cms:static/css/style.css')}?v=20150128" rel="stylesheet" type="text/css" />
+    <link href="${request.static_url('cms:static/css/style.css')}?v=20150203" rel="stylesheet" type="text/css" />
 </head>
 <body>
 <div id="wrap">
@@ -22,7 +22,7 @@
       <span tal:repeat="item view.get_display_languages()">
         <a tal:attributes="{'class':'active'} if view.locale==item[0] else {}" href="/locale/${item[0]}/">${item[1]}</a> |
       </span>
-      <a href="/locale/change/" tal:condition="len(view.get_available_languages)>2 ">&rarr;</a>
+      <a href="/locale/change/" tal:condition="len(view.get_available_languages)>2 "><span class="lang-more-lrt">&rarr;</span><span class="lang-more-rtl">&larr;</span></a>
     </div>
 
     <div id="header">

--- a/unicorecmsmnm/templates/base.pt
+++ b/unicorecmsmnm/templates/base.pt
@@ -22,7 +22,7 @@
       <span tal:repeat="item view.get_display_languages()">
         <a tal:attributes="{'class':'active'} if view.locale==item[0] else {}" href="/locale/${item[0]}/">${item[1]}</a> |
       </span>
-      <a href="/locale/change/" tal:condition="len(view.get_available_languages)>2 "><span class="lang-more-lrt">&rarr;</span><span class="lang-more-rtl">&larr;</span></a>
+      <a href="/locale/change/" tal:condition="len(view.get_available_languages)>2" class="lang-change">&hellip;</a>
     </div>
 
     <div id="header">

--- a/unicorecmsmnm/templates/base.pt
+++ b/unicorecmsmnm/templates/base.pt
@@ -22,7 +22,7 @@
       <span tal:repeat="item view.get_display_languages()">
         <a tal:attributes="{'class':'active'} if view.locale==item[0] else {}" href="/locale/${item[0]}/">${item[1]}</a> |
       </span>
-      <a href="/locale/change/">&rarr;</a>
+      <a href="/locale/change/" tal:condition="len(view.get_available_languages)>2 ">&rarr;</a>
     </div>
 
     <div id="header">

--- a/unicorecmsmnm/templates/locale_change.pt
+++ b/unicorecmsmnm/templates/locale_change.pt
@@ -1,0 +1,15 @@
+<div metal:use-macro="view.global_template">
+    <div metal:fill-slot="content">
+        <div class="home-content">
+        <div class="items">
+            <div class="box">
+                <div class="item" tal:repeat="lang languages">
+                    <div class="text">
+                        <a href="/locale/${lang[0]}/">${lang[1]}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
I'm not entirely happy using "&rarr;" for "more languages." For one thing, we need to flip it for RTL languages. For another, arrows are already used in interfaces for directional movement, which this is not.

How about "&hellip;" ?
